### PR TITLE
fix error and lint from clippy

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -1,0 +1,25 @@
+name: Buckle Linux CI
+
+on:
+  push:
+    branches:
+    - main
+  pull_request:
+    branches:
+    - main
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        default: true
+        components: rustfmt, clippy
+    - name: Build
+      run: cargo build

--- a/src/main.rs
+++ b/src/main.rs
@@ -105,7 +105,7 @@ fn get_releases(path: &Path) -> Result<Vec<Release>, Error> {
         .send()?;
     let text = releases.text_with_charset("utf-8")?;
     let mut file = File::create(releases_json_path)?;
-    file.write(text.as_bytes())?;
+    file.write_all(text.as_bytes())?;
     file.flush()?;
     Ok(serde_json::from_str(&text)?)
 }
@@ -145,7 +145,7 @@ fn download_http(version: String, output_dir: &Path) -> Result<PathBuf, Error> {
         return Ok(path);
     }
     if let Some(prefix) = path.parent() {
-        fs::create_dir_all(&prefix)?;
+        fs::create_dir_all(prefix)?;
     }
 
     let buck2_bin = File::create(&path)?;
@@ -184,7 +184,7 @@ fn get_buck2_path() -> Result<PathBuf, Error> {
     // or any version, but that isn't supported yet
     // TODO probably a regex here.
     if buck2_version == "latest" {
-        return Ok(download_http(buck2_version, &buck2_dir)?);
+        Ok(download_http(buck2_version, &buck2_dir)?)
     } else {
         // TODO fetch from git.
         todo!()


### PR DESCRIPTION
fix error and lint from clippy

One looked like real error,  tidy up the others

Tested with cargo clippy:

Before
```
 cargo clippy
    Checking buckle v0.1.0 (/home/alex/local/buckle)
error: written amount is not handled
   --> src/main.rs:108:5
    |
108 |     file.write(text.as_bytes())?;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: use `Write::write_all` instead, or handle partial writes
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unused_io_amount
    = note: `#[deny(clippy::unused_io_amount)]` on by default

warning: the borrowed expression implements the required traits
   --> src/main.rs:148:28
    |
148 |         fs::create_dir_all(&prefix)?;
    |                            ^^^^^^^ help: change this to: `prefix`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow
    = note: `#[warn(clippy::needless_borrow)]` on by default

warning: unneeded `return` statement
   --> src/main.rs:187:9
    |
187 |         return Ok(download_http(buck2_version, &buck2_dir)?);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_return
    = note: `#[warn(clippy::needless_return)]` on by default
    = help: remove `return`

warning: question mark operator is useless here
   --> src/main.rs:187:16
    |
187 |         return Ok(download_http(buck2_version, &buck2_dir)?);
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try removing question mark and `Ok()`: `download_http(buck2_version, &buck2_dir)`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_question_mark
    = note: `#[warn(clippy::needless_question_mark)]` on by default

warning: `buckle` (bin "buckle") generated 3 warnings
error: could not compile `buckle` due to previous error; 3 warnings emitted

```

After:

```
$ cargo clippy
    Checking buckle v0.1.0 (/home/alex/local/buckle)
    Finished dev [unoptimized + debuginfo] target(s) in 0.25s
```
