### PR TITLE
add simple integration test

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -23,3 +23,5 @@ jobs:
         components: rustfmt, clippy
     - name: Build
       run: cargo build
+    - name: Lint
+      run: cargo clippy

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -23,5 +23,7 @@ jobs:
         components: rustfmt, clippy
     - name: Build
       run: cargo build
+    - name: Test
+      run: cargo test
     - name: Lint
       run: cargo clippy

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,6 @@ serde = { version = "1.0.164", features = ["derive"] }
 serde_json = "1.0.96"
 url = { version = "2.4.0", features = ["serde"] }
 zstd = "0.12.3"
+
+[dev-dependencies]
+assert_cmd = "2.0.11"

--- a/tests/integration_buck2.rs
+++ b/tests/integration_buck2.rs
@@ -1,0 +1,15 @@
+#[cfg(test)]
+use assert_cmd::Command;
+
+/// Integration tests that buckle can download buck2 and run it with same arguments.
+#[test]
+fn test_buck2_latest() {
+    let mut cmd = Command::cargo_bin("buckle").unwrap();
+    cmd.arg("--version");
+    let assert = cmd.assert();
+    let stderr = String::from_utf8(assert.get_output().stderr.to_vec()).unwrap();
+    assert!(stderr.contains("/buckle"), "found {}", stderr);
+    let stdout = String::from_utf8(assert.get_output().stdout.to_vec()).unwrap();
+    assert!(stdout.starts_with("buck2 "), "found {}", stdout);
+    assert.success();
+}


### PR DESCRIPTION
add simple integration test

Added a test that checks buck is run from the buckle cache and that it succeeds.

buck2 has no named releases other than latest in the the github assets yet, so not yet testing the non-latest case.

Also connected it up to ci with cargo test

Tested with cargo test:

```
$ cargo test
Mon 12 Jun 22:21:54 BST 2023
    Finished test [unoptimized + debuginfo] target(s) in 0.04s
     Running unittests src/main.rs (target/debug/deps/buckle-b3885aa27b7b1fe5)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running tests/integration_buck2.rs (target/debug/deps/integration_buck2-5d0561e70b5f1ac2)

running 1 test
test test_buck2_latest ... ok
```

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/benbrittain/buckle/pull/4).
* #6
* #5
* __->__ #4
* #3