### PR TITLE
rename get_buck2_dir to get_buckle_dir

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,7 @@ use std::os::unix::fs::PermissionsExt;
 
 const BASE_URL: &str = "https://github.com/facebook/buck2/releases/download/";
 
-fn get_buck2_dir() -> Result<PathBuf, Error> {
+fn get_buckle_dir() -> Result<PathBuf, Error> {
     let mut dir = match env::var("BUCKLE_HOME") {
         Ok(home) => Ok(PathBuf::from(home)),
         Err(_) => match env::consts::OS {
@@ -174,7 +174,7 @@ fn read_buck2_version() -> Result<String, Error> {
 }
 
 fn get_buck2_path() -> Result<PathBuf, Error> {
-    let buck2_dir = get_buck2_dir()?;
+    let buck2_dir = get_buckle_dir()?;
     if !buck2_dir.exists() {
         fs::create_dir_all(&buck2_dir)?;
     }


### PR DESCRIPTION
rename get_buck2_dir to get_buckle_dir

the function returns BUCKLE_HOME or similar, not the dir buck2 is unpacked in

testes with cargo test

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/benbrittain/buckle/pull/5).
* #13
* #10
* #9
* #12
* #11
* #8
* #6
* #7
* __->__ #5