### PR TITLE
put buck2 in its own subdir of the buckle cache

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -263,7 +263,7 @@ fn read_buck2_version() -> Result<String, Error> {
 }
 
 fn get_buck2_dir() -> Result<PathBuf, Error> {
-    let buckle_dir = get_buckle_dir()?;
+    let buckle_dir = get_buckle_dir()?.join("buck2");
     if !buckle_dir.exists() {
         fs::create_dir_all(&buckle_dir)?;
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,6 @@ use std::os::unix::fs::PermissionsExt;
 #[cfg(unix)]
 use std::time::SystemTime;
 
-const BASE_URL: &str = "https://github.com/facebook/buck2/releases/download";
 const BUCK_RELEASE_URL: &str = "https://github.com/facebook/buck2/tags";
 
 fn get_buckle_dir() -> Result<PathBuf, Error> {
@@ -83,6 +82,13 @@ fn get_buck2_project_root() -> Option<&'static Path> {
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
+pub struct Asset {
+    pub name: String,
+    pub browser_download_url: Url,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub struct Release {
     pub url: Url,
     pub html_url: Url,
@@ -101,7 +107,7 @@ pub struct Release {
     pub created_at: Option<String>,
     pub published_at: Option<String>,
     pub author: serde_json::Value,
-    pub assets: Vec<serde_json::Value>,
+    pub assets: Vec<Asset>,
 }
 
 fn get_releases(path: &Path) -> Result<Vec<Release>, Error> {
@@ -156,16 +162,33 @@ fn get_arch() -> Result<&'static str, Error> {
 fn download_http(version: String, output_dir: &Path) -> Result<PathBuf, Error> {
     let releases = get_releases(output_dir)?;
     let mut dir_path = output_dir.to_path_buf();
-    let mut release_found = false;
+
+    let mut unpackable = None;
+    let mut verbatim = vec![];
+    let arch = get_arch()?;
+
     for release in releases {
-        if release.tag_name == version {
-            dir_path.push(release.target_commitish);
-            release_found = true;
+        if release.name.as_ref() == Some(&version) {
+            if release.tag_name == version {
+                dir_path.push(release.target_commitish);
+            }
+            for asset in release.assets {
+                let name = asset.name;
+                let url = asset.browser_download_url;
+                if name == format!("buck2-{}.zst", arch) {
+                    unpackable = Some((name, url));
+                } else if name == "prelude" {
+                    verbatim.push((name, url));
+                }
+            }
         }
     }
-    if !release_found {
+
+    let (name, url) = if let Some(unpackable) = unpackable {
+        unpackable
+    } else {
         return Err(anyhow!("{version} was not available. Please check '{BUCK_RELEASE_URL}' for available releases."));
-    }
+    };
 
     let binary_path: PathBuf = [&dir_path, Path::new("buck2")].iter().collect();
     if binary_path.exists() {
@@ -176,21 +199,21 @@ fn download_http(version: String, output_dir: &Path) -> Result<PathBuf, Error> {
     // Create the release directory if it doesn't exist
     fs::create_dir_all(&dir_path).with_context(|| anyhow!("problem creating {:?}", dir_path))?;
 
-    {
-        // Fetch the prelude hash and store it, do this before the binary so we don't see a partial hash
+    for (name, url) in verbatim {
+        // Fetch the verbatim items hash and store, do this before the binary so we don't see a partial hash
         // We do this as the complete executable is atomic via tmp_file rename
-        let prelude_path: PathBuf = [&dir_path, Path::new("prelude_hash")].iter().collect();
-        let resp = reqwest::blocking::get(format!("{BASE_URL}/{version}/prelude_hash"))?;
-        let mut prelude_hash = File::create(prelude_path)?;
-        prelude_hash.write_all(&resp.bytes()?)?;
-        prelude_hash.flush()?;
+        let verbatim_path: PathBuf = [&dir_path, Path::new(&name)].iter().collect();
+        let resp = reqwest::blocking::get(url)?;
+        let mut verbatim_file = File::create(&verbatim_path)
+            .with_context(|| anyhow!("problem creating {:?}", verbatim_path))?;
+        verbatim_file.write_all(&resp.bytes()?)?;
+        verbatim_file.flush()?;
     }
 
     // Fetch the buck2 archive, decode it, make it executable
     let mut tmp_file = NamedTempFile::new_in(&dir_path)?;
-    let arch = get_arch()?;
-    eprintln!("buckle: fetching buck2 {version}");
-    let resp = reqwest::blocking::get(format!("{BASE_URL}/{version}/buck2-{arch}.zst"))?;
+    eprintln!("buckle: fetching {name} {version}");
+    let resp = reqwest::blocking::get(url)?;
     zstd::stream::copy_decode(resp, &tmp_file)?;
     tmp_file.flush()?;
     #[cfg(unix)]

--- a/tests/integration_buck2.rs
+++ b/tests/integration_buck2.rs
@@ -25,3 +25,15 @@ fn test_buck2_specific_version() {
     assert!(stdout.starts_with("buck2 "), "found {}", stdout);
     assert.success();
 }
+
+#[test]
+fn test_buck2_fail() {
+    let tmpdir = tempfile::TempDir::new().unwrap();
+    let mut cmd = Command::cargo_bin("buckle").unwrap();
+    cmd.env("BUCKLE_CACHE", tmpdir.path().as_os_str());
+    cmd.arg("--totally-unknown-argument");
+    let assert = cmd.assert();
+    let stderr = String::from_utf8(assert.get_output().stderr.to_vec()).unwrap();
+    assert!(stderr.contains("error: Found argument"), "found {}", stderr);
+    assert.failure();
+}

--- a/tests/integration_buck2.rs
+++ b/tests/integration_buck2.rs
@@ -4,7 +4,9 @@ use assert_cmd::Command;
 /// Integration test that buckle can download buck2 and run it with same arguments.
 #[test]
 fn test_buck2_latest() {
+    let tmpdir = tempfile::TempDir::new().unwrap();
     let mut cmd = Command::cargo_bin("buckle").unwrap();
+    cmd.env("BUCKLE_CACHE", tmpdir.path().as_os_str());
     cmd.arg("--version");
     let assert = cmd.assert();
     let stdout = String::from_utf8(assert.get_output().stdout.to_vec()).unwrap();
@@ -16,7 +18,9 @@ fn test_buck2_latest() {
 /// version
 #[test]
 fn test_buck2_specific_version() {
+    let tmpdir = tempfile::TempDir::new().unwrap();
     let mut cmd = Command::cargo_bin("buckle").unwrap();
+    cmd.env("BUCKLE_CACHE", tmpdir.path().as_os_str());
     cmd.env("USE_BUCK2_VERSION", "2023-07-15");
     cmd.arg("--version");
     // TODO verify the right version is download after buck2 properly states it's version


### PR DESCRIPTION
put buck2 in its own subdir of the buckle cache

tested via cargo test

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/benbrittain/buckle/pull/6).
* __->__ #6
* #8
* #12
* #18
* #9