### PR TITLE
test for preserve exit status code

### DIFF
--- a/tests/integration_buck2.rs
+++ b/tests/integration_buck2.rs
@@ -25,3 +25,15 @@ fn test_buck2_specific_version() {
     assert!(stdout.starts_with("buck2 "), "found {}", stdout);
     assert.success();
 }
+
+#[test]
+fn test_buck2_fail() {
+    let tmpdir = tempfile::TempDir::new().unwrap();
+    let mut cmd = Command::cargo_bin("buckle").unwrap();
+    cmd.env("BUCKLE_CACHE", tmpdir.path().as_os_str());
+    cmd.arg("--totally-unknown-argument");
+    let assert = cmd.assert();
+    let stderr = String::from_utf8(assert.get_output().stderr.to_vec()).unwrap();
+    assert!(stderr.contains("error: Found argument"), "found {}", stderr);
+    assert.failure();
+}


### PR DESCRIPTION
test for preserve exit status code

the use of the status code was included in a45d2c896c62, but the test was missed out so rebasing

tested with: cargo test

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/benbrittain/buckle/pull/9).
* #8
* #18
* __->__ #9