### PR TITLE
toml config covering existing buck2 latest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ reqwest = { version = "0.11.18", default-features=false, features = ["blocking",
 serde = { version = "1.0.164", features = ["derive"] }
 serde_json = "1.0.96"
 tempfile = "3.6.0"
+toml = "0.7.4"
 url = { version = "2.4.0", features = ["serde"] }
 zstd = "0.12.3"
 once_cell = "1.18.0"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Buckle
 
-Buckle is a launcher for [Buck2](https://buck2.build/). It manages Buck2 on a per-project basis. This enables a project or team to do seamless upgrades of their build system tooling.
+Buckle is a launcher for buck2 and other binaries. It manages what version of a binary is used on a per-project basis. It picks a good version downloads it from the official releases, and then passes command line arguments through to the managed buck2 binary.
 
 It is designed to be minimally intrusive. Buckle only manages fetching Buck2 and enforcing the prelude is upgraded in sync.
 
@@ -22,6 +22,8 @@ cargo install buckle
 ```
 
 ## How To Use
+
+In general you use buckle like you would the tool it is running for you.  Behind the scenes it downloads archives, from which it runs binaries.
 
 ### Invoke buck2
 The most basic thing Buckle does is invoke the `buck2` binary. Use it as follows:
@@ -74,8 +76,62 @@ MacOS: `$HOME/Library/Caches/buckle`
 
 Windows `%LocalAppData%/buckle`
 
-
 you may also specify an override with the `BUCKLE_CACHE` environment variable.
 ```bash
 export BUCKLE_CACHE=/tmp
+``
+
+### Calling tools from config
+
+Here are some example invocations.
+
+Exercise the default buck2 config: `buckle`
+
+Test some scripts that download and run tools using the installed buckle. NB, you can remove the .toml extension if you install the scripts, its just there to show they are valid toml files:
+```shell
+    ../examples/buck2.toml
+    ../examples/bazel7.toml
 ```
+
+Test a config from build:
+```shell
+    BUCKLE_CONFIG_FILE=examples/bazel7.toml cargo run -- version
+```
+
+Test a config using the installed buckle:
+```shell
+    BUCKLE_CONFIG_FILE=examples/bazel7.toml buckle version
+```
+
+## Environment variables
+
+`BUCKLE_CONFIG_FILE` points to a file to load config from
+
+`BUCKLE_CONFIG` is an environment variable that can hold config. Mostly useful for testing.
+
+`BUCKLE_SCRIPT` is used to tell buckle its being invoked as a script.  We use an env var for this as all command line arguments need to be passed to the underling tool.
+
+`BUCKLE_BINARY` tells buckle which binary to run if there are multiple in the config
+
+## Config syntax
+
+`buckle` config is in tsoml, and allows you to specify which archives to download and cache and which binaries to run from those cached archives
+
+The config file helps buckle find the archives to download and unpack, and from them which binaries to run
+
+If there is no config, buckle with run buck2 with default config pointing to buck2 latest from github
+
+For example config and how to use buckle as a #! interpreter see [examples](./examples/)
+
+### Patterns for archives
+
+When naming the archive you are looking for you can specify using a simple templating syntax.
+
+`%version%`:  the artifact release name;
+
+`%target%`: buckles view of the host's [rust target triple](https://rust-lang.github.io/rfcs/0131-target-specification.html);
+
+`%arch%`: the architecture part of the triple
+
+`%os%`: the os part of the triple
+

--- a/examples/bazel7.toml
+++ b/examples/bazel7.toml
@@ -1,0 +1,10 @@
+#!/usr/bin/env -S BUCKLE_SCRIPT=1 buckle
+[archives.bazel]
+source.github.owner = "bazelbuild"
+source.github.repo = "bazel"
+source.github.version = "7.0.0-pre.20230530.3"
+artifact_pattern = "bazel-%version%-%os%-%arch%"
+package_type = "single_file"
+
+[binaries.bazel]
+provided_by = "bazel"

--- a/examples/buck2.toml
+++ b/examples/buck2.toml
@@ -1,0 +1,10 @@
+#!/usr/bin/env -S BUCKLE_SCRIPT=1 buckle
+[archives.buck2]
+source.github.owner = "facebook"
+source.github.repo = "buck2"
+source.github.version = "latest"
+artifact_pattern = "buck2-%target%.zst"
+package_type = "zstd_single_file"
+
+[binaries.buck2]
+provided_by = "buck2"

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,81 @@
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct GithubRelease {
+    pub owner: String,
+    pub repo: String,
+    pub version: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BuckleSource {
+    Github(GithubRelease),
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+// Some tools ship as a single file, others as a compressed directory
+pub enum PackageType {
+    SingleFile,
+    ZstdSingleFile,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+// Archives contain binaries, they are downloaded from sources
+pub struct ArchiveConfig {
+    pub source: BuckleSource,
+    pub package_type: PackageType,
+    /// Artifact string regex
+    pub artifact_pattern: String,
+    // TODO things like checksums,  cache timeouts etc
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+// Binaries are runnable from the expanded archive in the cache area
+pub struct BinaryConfig {
+    pub provided_by: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+// Top level Buckle configuration
+pub struct BuckleConfig {
+    pub archives: HashMap<String, ArchiveConfig>,
+    pub binaries: HashMap<String, BinaryConfig>,
+}
+
+impl BuckleConfig {
+    // a fallback for when no config is found
+    pub fn buck2_latest() -> Self {
+        let config_toml = r#"
+        [archives.buck2]
+        source.github.owner = "facebook"
+        source.github.repo = "buck2"
+        source.github.version = "latest"
+        artifact_pattern = "buck2-%target%.zst"
+        package_type = "zstd_single_file"
+
+        [binaries.buck2]
+        provided_by = "buck2"
+        "#;
+        toml::from_str(config_toml).unwrap()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_buck2_latest() {
+        let buckle_config: BuckleConfig = BuckleConfig::buck2_latest();
+        assert_eq!(buckle_config.archives.len(), 1);
+        assert_eq!(buckle_config.binaries.len(), 1);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -263,7 +263,7 @@ fn read_buck2_version() -> Result<String, Error> {
 }
 
 fn get_buck2_dir() -> Result<PathBuf, Error> {
-    let buckle_dir = get_buckle_dir()?;
+    let buckle_dir = get_buckle_dir()?.join("buck2");
     if !buckle_dir.exists() {
         fs::create_dir_all(&buckle_dir)?;
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,12 @@
-use anyhow::{anyhow, Context, Error};
+use anyhow::{anyhow, bail, Context, Error};
 use ini::Ini;
 use once_cell::sync::OnceCell;
 use serde::{Deserialize, Serialize};
-use std::io::{Read, Write};
 use std::{
     env,
     fs::{self, File},
+    ffi::{OsStr, OsString},
+    io::{self, Read, Write},
     path::{Path, PathBuf},
     process::{Command, Stdio},
 };
@@ -17,7 +18,16 @@ use std::os::unix::fs::PermissionsExt;
 #[cfg(unix)]
 use std::time::SystemTime;
 
-const BUCK_RELEASE_URL: &str = "https://github.com/facebook/buck2/tags";
+mod config;
+
+use config::{ArchiveConfig, BuckleConfig, BuckleSource, GithubRelease, PackageType};
+
+const BUCKLE_BINARY: &str = "BUCKLE_BINARY";
+const BUCKLE_CONFIG: &str = "BUCKLE_CONFIG";
+const BUCKLE_CONFIG_FILE: &str = "BUCKLE_CONFIG_FILE";
+const BUCKLE_SCRIPT: &str = "BUCKLE_SCRIPT";
+const BUCKLE_HOME: &str = "BUCKLE_HOME";
+const BUCKLE_REPO_CONFIG: &str = ".buckleconfig.toml";
 
 fn get_buckle_dir() -> Result<PathBuf, Error> {
     let mut dir = match env::var("BUCKLE_CACHE") {
@@ -110,7 +120,7 @@ pub struct Release {
     pub assets: Vec<Asset>,
 }
 
-fn get_releases(path: &Path) -> Result<Vec<Release>, Error> {
+fn get_releases(gh_release: &GithubRelease, path: &Path) -> Result<Vec<Release>, Error> {
     let mut releases_json_path = path.to_path_buf();
     releases_json_path.push("releases.json");
 
@@ -133,7 +143,10 @@ fn get_releases(path: &Path) -> Result<Vec<Release>, Error> {
         .user_agent("buckle")
         .build()?;
     let releases = client
-        .get("http://api.github.com/repos/facebook/buck2/releases")
+        .get(format!(
+            "http://api.github.com/repos/{}/{}/releases",
+            gh_release.owner, gh_release.repo
+        ))
         .send()?;
     let text = releases.text_with_charset("utf-8")?;
     let mut file = File::create(releases_json_path)?;
@@ -142,7 +155,9 @@ fn get_releases(path: &Path) -> Result<Vec<Release>, Error> {
     Ok(serde_json::from_str(&text)?)
 }
 
-fn get_arch() -> Result<&'static str, Error> {
+// Approximate the target triple for the current platform
+// as per https://rust-lang.github.io/rfcs/0131-target-specification.html
+fn get_target() -> Result<&'static str, Error> {
     Ok(match env::consts::ARCH {
         "x86_64" => match env::consts::OS {
             "linux" => "x86_64-unknown-linux-gnu",
@@ -159,23 +174,45 @@ fn get_arch() -> Result<&'static str, Error> {
     })
 }
 
-fn download_http(version: String, output_dir: &Path) -> Result<PathBuf, Error> {
-    let releases = get_releases(output_dir)?;
+fn get_triple_os() -> &'static str {
+    match env::consts::OS {
+        "linux" => "linux",
+        "macos" => "darwin",
+        "windows" => "windows",
+        os => panic!("Unsupported OS {}", os),
+    }
+}
+
+fn download_from_github(
+    artifact_pattern: &str,
+    gh_release: &GithubRelease,
+    output_dir: &Path,
+) -> Result<(PathBuf, reqwest::blocking::Response), Error> {
+    let releases = get_releases(gh_release, output_dir)?;
+
     let mut dir_path = output_dir.to_path_buf();
 
     let mut unpackable = None;
     let mut verbatim = vec![];
-    let arch = get_arch()?;
+    // simple templating, we'll need this even if we add regex support
+    let mut artifact_name = artifact_pattern.to_string();
+    artifact_name = artifact_name.replace("%version%", &gh_release.version);
+    artifact_name = artifact_name.replace("%arch%", env::consts::ARCH);
+    artifact_name = artifact_name.replace("%os%", get_triple_os());
+    artifact_name = artifact_name.replace("%target%", get_target()?);
 
     for release in releases {
-        if release.name.as_ref() == Some(&version) {
+        if release.name.as_ref() == Some(&gh_release.version) {
             if release.tag_name == version {
                 dir_path.push(release.target_commitish);
+            } else {
+                // TODO use sha256 checksum if present
+                path.push(release.name.ok_or_else(|| anyhow!("Release has no name"))?);
             }
             for asset in release.assets {
                 let name = asset.name;
                 let url = asset.browser_download_url;
-                if name == format!("buck2-{}.zst", arch) {
+                if name == artifact_name {
                     unpackable = Some((name, url));
                 } else if name == "prelude" {
                     verbatim.push((name, url));
@@ -187,18 +224,30 @@ fn download_http(version: String, output_dir: &Path) -> Result<PathBuf, Error> {
     let (name, url) = if let Some(unpackable) = unpackable {
         unpackable
     } else {
-        return Err(anyhow!("{version} was not available. Please check '{BUCK_RELEASE_URL}' for available releases."));
+        bail!(
+            "Could not find {}. Its possible {} has changed their releasing method for {}. Please update buckle.",
+            artifact_name,
+            gh_release.owner,
+            gh_release.repo
+        )
     };
 
-    let binary_path: PathBuf = [&dir_path, Path::new("buck2")].iter().collect();
-    if binary_path.exists() {
-        // unpacked binary already present, so do nothing
-        return Ok(dir_path);
+    if !path.exists() {
+        fs::create_dir_all(&dir_path).with_context(|| anyhow!("error creating {:?}", path))?;
     }
 
-    // Create the release directory if it doesn't exist
-    fs::create_dir_all(&dir_path).with_context(|| anyhow!("problem creating {:?}", dir_path))?;
+    Ok((dir_path, reqwest::blocking::get(url)?))
+}
 
+fn extract<R>(
+    unpacked_name: &str,
+    package_type: &PackageType,
+    mut archive_stream: R,
+    dir_path: PathBuf,
+) -> Result<PathBuf, Error>
+where
+    R: Read,
+{
     for (name, url) in verbatim {
         // Fetch the verbatim items hash and store, do this before the binary so we don't see a partial hash
         // We do this as the complete executable is atomic via tmp_file rename
@@ -210,11 +259,15 @@ fn download_http(version: String, output_dir: &Path) -> Result<PathBuf, Error> {
         verbatim_file.flush()?;
     }
 
-    // Fetch the buck2 archive, decode it, make it executable
     let mut tmp_file = NamedTempFile::new_in(&dir_path)?;
-    eprintln!("buckle: fetching {name} {version}");
-    let resp = reqwest::blocking::get(url)?;
-    zstd::stream::copy_decode(resp, &tmp_file)?;
+    match package_type {
+        PackageType::SingleFile => {
+            io::copy(&mut archive_stream, &mut tmp_file)
+                .with_context(|| anyhow!("problem copying to tmp_file"))?;
+        }
+        PackageType::ZstdSingleFile => zstd::stream::copy_decode(archive_stream, &tmp_file)?,
+    }
+
     tmp_file.flush()?;
     #[cfg(unix)]
     {
@@ -247,6 +300,49 @@ fn get_expected_prelude_hash() -> &'static str {
     expected_hash
 }
 
+fn download(
+    binary_name: &str,
+    archive_config: &ArchiveConfig,
+    output_dir: &Path,
+) -> Result<PathBuf, Error> {
+    let (dir_path, stream) = match &archive_config.source {
+        BuckleSource::Github(ref gh_release) => {
+            download_from_github(&archive_config.artifact_pattern, gh_release, output_dir)?
+        }
+    };
+    extract(binary_name, &archive_config.package_type, stream, dir_path)
+}
+
+fn get_binary_path(config: BuckleConfig, binary_name: Option<&String>) -> Result<PathBuf, Error> {
+    let binary_name = if let Some(binary_name) = binary_name {
+        binary_name
+    } else if config.binaries.len() == 1 {
+        // only one so default to it
+        config.binaries.keys().next().unwrap()
+    } else {
+        bail!("No binary name provided");
+    };
+
+    let bin_config = config
+        .binaries
+        .get(binary_name)
+        .ok_or_else(|| anyhow!("No binary named {} in buckle config", binary_name))?;
+    let archive_name = &bin_config.provided_by;
+    let archive_config = config
+        .archives
+        .get(archive_name)
+        .ok_or_else(|| anyhow!("No archive named {} in buckle config", archive_name))?;
+
+    let archive_dir = get_buckle_dir()?.join(archive_name);
+
+    if !archive_dir.exists() {
+        fs::create_dir_all(&archive_dir)
+            .with_context(|| anyhow!("error creating {:?}", archive_dir))?;
+    }
+
+    download(binary_name, archive_config, &archive_dir).map_err(Error::into)
+}
+
 fn read_buck2_version() -> Result<String, Error> {
     if let Ok(version) = env::var("USE_BUCK2_VERSION") {
         return Ok(version);
@@ -270,6 +366,48 @@ fn get_buck2_dir() -> Result<PathBuf, Error> {
 
     let buck2_version = read_buck2_version()?;
     download_http(buck2_version, &buckle_dir)
+}
+
+fn load_config(args: &mut env::ArgsOs) -> Result<BuckleConfig, Error> {
+    if let Ok(config) = env::var(BUCKLE_CONFIG) {
+        // Short circuit if the user has given us a config in the environment
+        return Ok(toml::from_str(&config)?);
+    }
+
+    let config_file = if env::var(BUCKLE_SCRIPT).is_ok() {
+        Some(PathBuf::from(args.next().unwrap().to_str().unwrap()))
+    } else {
+        match env::var(BUCKLE_CONFIG_FILE) {
+            Ok(file) => Some(PathBuf::from(file)),
+            // Then try repo level config
+            Err(_) => {
+                if let Some(mut root) = find_project_root()? {
+                    root.push(BUCKLE_REPO_CONFIG);
+                    if root.exists() {
+                        Some(root)
+                    } else {
+                        None
+                    }
+                } else {
+                    None
+                }
+            }
+        }
+    };
+
+    if let Some(config_file) = config_file {
+        let config = &fs::read_to_string(&config_file).with_context(|| {
+            format!(
+                "Could not read config file {:?}",
+                config_file.to_string_lossy()
+            )
+        })?;
+        let config = toml::from_str(config)?;
+        Ok(config)
+    } else {
+        //dbg!("No config file found, using builtin buck2 defaults");
+        Ok(BuckleConfig::buck2_latest())
+    }
 }
 
 // Warn if the prelude does not match expected
@@ -302,6 +440,22 @@ fn verify_prelude(prelude_path: &str) {
     }
 }
 
+// What binary are we trying to run from the buckle config?
+fn get_binary_name(invoked_as: Option<&OsString>) -> Option<String> {
+    if let Ok(binary_name) = env::var(BUCKLE_BINARY) {
+        Some(binary_name)
+    } else if let Some(invoked_as) = invoked_as {
+        let base_name = Path::new(&invoked_as).file_name();
+        if base_name == Some(OsStr::new("buckle")) {
+            None
+        } else {
+            base_name.and_then(|v| v.to_str()).map(|v| v.to_string())
+        }
+    } else {
+        None
+    }
+}
+
 /// Notify user of prelude mismatch and suggest solution.
 // TODO make this much better
 fn mismatched_prelude_msg(absolute_prelude_path: &Path, prelude_hash: &str, expected_hash: &str) {
@@ -313,8 +467,8 @@ fn mismatched_prelude_msg(absolute_prelude_path: &Path, prelude_hash: &str, expe
 }
 
 fn main() -> Result<(), Error> {
-    let buck2_path: PathBuf = [get_buck2_dir()?, PathBuf::from("buck2")].iter().collect();
-    if !buck2_path.exists() {
+    let binary_path: PathBuf = [get_buckle_dir()?, PathBuf::from("buck2")].iter().collect();
+    if !binary_path.exists() {
         return Err(anyhow!(
             "The buckle cache is corrupted. Suggested fix is to remove {}",
             get_buckle_dir()?.display()
@@ -323,8 +477,8 @@ fn main() -> Result<(), Error> {
 
     // mode() is only available on unix systems
     #[cfg(unix)]
-    if buck2_path.exists() {
-        let metadata = buck2_path.metadata()?;
+    if binary_path.exists() {
+        let metadata = binary_path.metadata()?;
         let permissions = metadata.permissions();
         let is_exec = metadata.is_file() && permissions.mode() & 0o111 != 0;
         if !is_exec {
@@ -353,21 +507,34 @@ fn main() -> Result<(), Error> {
             }
         }
     }
+    // Collect information intended for invoked binary.
 
     // Collect information indented for buck2 binary.
     let mut args = env::args_os();
-    args.next(); // Skip buckle
+    // Figure out what binary we are trying to run.
+    let invoked_as = args.next();
+    let binary_name = get_binary_name(invoked_as.as_ref());
+    let binary_name = binary_name;
+    let buckle_config = load_config(&mut args)?;
+    let binary_path = get_binary_path(buckle_config, binary_name.as_ref())?;
+
+    if env::var(BUCKLE_SCRIPT).is_err() {
+        eprintln!("buckle is running {:?}", binary_path)
+    }
+
+    // Remove so any recursive buckle calls need their own #! to be in script mode
+    env::remove_var(BUCKLE_SCRIPT);
     let envs = env::vars_os();
 
     // Pass all file descriptors through as well.
-    let status = Command::new(&buck2_path)
+    let status = Command::new(&binary_path)
         .args(args)
         .envs(envs)
         .stdin(Stdio::inherit())
         .stdout(Stdio::inherit())
         .stderr(Stdio::inherit())
         .output()
-        .unwrap_or_else(|_| panic!("Failed to execute {}", &buck2_path.display()))
+        .unwrap_or_else(|_| panic!("Failed to execute {}", &binary_path.display()))
         .status;
 
     if !status.success() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,6 @@ use std::os::unix::fs::PermissionsExt;
 #[cfg(unix)]
 use std::time::SystemTime;
 
-const BASE_URL: &str = "https://github.com/facebook/buck2/releases/download";
 const BUCK_RELEASE_URL: &str = "https://github.com/facebook/buck2/tags";
 
 fn get_buckle_dir() -> Result<PathBuf, Error> {
@@ -83,6 +82,13 @@ fn get_buck2_project_root() -> Option<&'static Path> {
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
+pub struct Asset {
+    pub name: String,
+    pub browser_download_url: Url,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub struct Release {
     pub url: Url,
     pub html_url: Url,
@@ -101,7 +107,7 @@ pub struct Release {
     pub created_at: Option<String>,
     pub published_at: Option<String>,
     pub author: serde_json::Value,
-    pub assets: Vec<serde_json::Value>,
+    pub assets: Vec<Asset>,
 }
 
 fn get_releases(path: &Path) -> Result<Vec<Release>, Error> {
@@ -156,16 +162,33 @@ fn get_arch() -> Result<&'static str, Error> {
 fn download_http(version: String, output_dir: &Path) -> Result<PathBuf, Error> {
     let releases = get_releases(output_dir)?;
     let mut dir_path = output_dir.to_path_buf();
-    let mut release_found = false;
+
+    let mut unpackable = None;
+    let mut verbatim = vec![];
+    let arch = get_arch()?;
+
     for release in releases {
-        if release.tag_name == version {
-            dir_path.push(release.target_commitish);
-            release_found = true;
+        if release.name.as_ref() == Some(&version) {
+            if release.tag_name == version {
+                dir_path.push(release.target_commitish);
+            }
+            for asset in release.assets {
+                let name = asset.name;
+                let url = asset.browser_download_url;
+                if name == format!("buck2-{}.zst", arch) {
+                    unpackable = Some((name, url));
+                } else if name == "prelude" {
+                    verbatim.push((name, url));
+                }
+            }
         }
     }
-    if !release_found {
+
+    let (name, url) = if let Some(unpackable) = unpackable {
+        unpackable
+    } else {
         return Err(anyhow!("{version} was not available. Please check '{BUCK_RELEASE_URL}' for available releases."));
-    }
+    };
 
     let binary_path: PathBuf = [&dir_path, Path::new("buck2")].iter().collect();
     if binary_path.exists() {
@@ -176,21 +199,21 @@ fn download_http(version: String, output_dir: &Path) -> Result<PathBuf, Error> {
     // Create the release directory if it doesn't exist
     fs::create_dir_all(&dir_path).with_context(|| anyhow!("problem creating {:?}", dir_path))?;
 
-    {
-        // Fetch the prelude hash and store it, do this before the binary so we don't see a partial hash
+    for (name, url) in verbatim {
+        // Fetch the verbatim items hash and store, do this before the binary so we don't see a partial hash
         // We do this as the complete executable is atomic via tmp_file rename
-        let prelude_path: PathBuf = [&dir_path, Path::new("prelude_hash")].iter().collect();
-        let resp = reqwest::blocking::get(format!("{BASE_URL}/{version}/prelude_hash"))?;
-        let mut prelude_hash = File::create(prelude_path)?;
-        prelude_hash.write_all(&resp.bytes()?)?;
-        prelude_hash.flush()?;
+        let verbatim_path: PathBuf = [&dir_path, Path::new(&name)].iter().collect();
+        let resp = reqwest::blocking::get(url)?;
+        let mut verbatim_file = File::create(&verbatim_path)
+            .with_context(|| anyhow!("problem creating {:?}", verbatim_path))?;
+        verbatim_file.write_all(&resp.bytes()?)?;
+        verbatim_file.flush()?;
     }
 
     // Fetch the buck2 archive, decode it, make it executable
     let mut tmp_file = NamedTempFile::new_in(&dir_path)?;
-    let arch = get_arch()?;
-    eprintln!("buckle: fetching buck2 {version}");
-    let resp = reqwest::blocking::get(format!("{BASE_URL}/{version}/buck2-{arch}.zst"))?;
+    eprintln!("buckle: fetching {name} {version}");
+    let resp = reqwest::blocking::get(url)?;
     zstd::stream::copy_decode(resp, &tmp_file)?;
     tmp_file.flush()?;
     #[cfg(unix)]

--- a/tests/bazel7.toml
+++ b/tests/bazel7.toml
@@ -1,0 +1,10 @@
+#!/usr/bin/env -S BUCKLE_SCRIPT=1 BAZEL_BINARY=buck2 cargo run --
+[archives.bazel]
+source.github.owner = "bazelbuild"
+source.github.repo = "bazel"
+source.github.version = "7.0.0-pre.20230530.3"
+artifact_pattern = "bazel-%version%-%os%-%arch%"
+package_type = "single_file"
+
+[binaries.bazel]
+provided_by = "bazel"

--- a/tests/buck2.toml
+++ b/tests/buck2.toml
@@ -1,0 +1,10 @@
+#!/usr/bin/env -S BUCKLE_SCRIPT=1 BAZEL_BINARY=buck2 cargo run --
+[archives.buck2]
+source.github.owner = "facebook"
+source.github.repo = "buck2"
+source.github.version = "latest"
+artifact_pattern = "buck2-%target%.zst"
+package_type = "zstd_single_file"
+
+[binaries.buck2]
+provided_by = "buck2"

--- a/tests/integration_bazel.rs
+++ b/tests/integration_bazel.rs
@@ -1,0 +1,32 @@
+#[cfg(test)]
+use assert_cmd::Command;
+
+/// Integration tests that buckle can download bazel and run it with same arguments.
+#[test]
+fn test_bazel_fromenv() {
+    let tmpdir = tempfile::TempDir::new().unwrap();
+    let mut cmd = Command::cargo_bin("buckle").unwrap();
+    cmd.env("BUCKLE_HOME", tmpdir.path().as_os_str());
+    cmd.env("BUCKLE_BINARY", "bazel");
+    cmd.env(
+        "BUCKLE_CONFIG",
+        r#"
+    [archives.bazel]
+    source.github.owner = "bazelbuild"
+    source.github.repo = "bazel"
+    source.github.version = "7.0.0-pre.20230530.3"
+    artifact_pattern = "bazel-%version%-%os%-%arch%"
+    package_type = "single_file"
+
+    [binaries.bazel]
+    provided_by = "bazel"
+    "#,
+    );
+    cmd.arg("--version");
+    let assert = cmd.assert();
+    let stderr = String::from_utf8(assert.get_output().stderr.to_vec()).unwrap();
+    assert!(stderr.contains("/buckle/bazel/"), "found {}", stderr);
+    let stdout = String::from_utf8(assert.get_output().stdout.to_vec()).unwrap();
+    assert!(stdout.starts_with("bazel "), "found {}", stdout);
+    assert.success();
+}

--- a/tests/integration_buck2.rs
+++ b/tests/integration_buck2.rs
@@ -25,3 +25,13 @@ fn test_buck2_specific_version() {
     assert!(stdout.starts_with("buck2 "), "found {}", stdout);
     assert.success();
 }
+
+#[test]
+fn test_buck2_fail() {
+    let mut cmd = Command::cargo_bin("buckle").unwrap();
+    cmd.arg("--totally-unknown-argument");
+    let assert = cmd.assert();
+    let stderr = String::from_utf8(assert.get_output().stderr.to_vec()).unwrap();
+    assert!(stderr.contains("error: Found argument"), "found {}", stderr);
+    assert.failure();
+}

--- a/tests/integration_buck2.rs
+++ b/tests/integration_buck2.rs
@@ -4,7 +4,9 @@ use assert_cmd::Command;
 /// Integration test that buckle can download buck2 and run it with same arguments.
 #[test]
 fn test_buck2_latest() {
+    let tmpdir = tempfile::TempDir::new().unwrap();
     let mut cmd = Command::cargo_bin("buckle").unwrap();
+    cmd.env("BUCKLE_CACHE", tmpdir.path().as_os_str());
     cmd.arg("--version");
     let assert = cmd.assert();
     let stdout = String::from_utf8(assert.get_output().stdout.to_vec()).unwrap();
@@ -16,7 +18,9 @@ fn test_buck2_latest() {
 /// version
 #[test]
 fn test_buck2_specific_version() {
+    let tmpdir = tempfile::TempDir::new().unwrap();
     let mut cmd = Command::cargo_bin("buckle").unwrap();
+    cmd.env("BUCKLE_CACHE", tmpdir.path().as_os_str());
     cmd.env("USE_BUCK2_VERSION", "2023-07-15");
     cmd.arg("--version");
     // TODO verify the right version is download after buck2 properly states it's version
@@ -28,7 +32,9 @@ fn test_buck2_specific_version() {
 
 #[test]
 fn test_buck2_fail() {
+    let tmpdir = tempfile::TempDir::new().unwrap();
     let mut cmd = Command::cargo_bin("buckle").unwrap();
+    cmd.env("BUCKLE_CACHE", tmpdir.path().as_os_str());
     cmd.arg("--totally-unknown-argument");
     let assert = cmd.assert();
     let stderr = String::from_utf8(assert.get_output().stderr.to_vec()).unwrap();


### PR DESCRIPTION
toml config covering existing buck2 latest

basic idea is that buckle downloads and caches archives,  and archives provide binaries

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/benbrittain/buckle/pull/10).
* #13
* __->__ #10
* #6
* #8
* #12
* #18
* #9