### PR TITLE
detect macos as darwin

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,7 @@ use std::os::unix::fs::PermissionsExt;
 
 const BASE_URL: &str = "https://github.com/facebook/buck2/releases/download/";
 
-fn get_buck2_dir() -> Result<PathBuf, Error> {
+fn get_buckle_dir() -> Result<PathBuf, Error> {
     let mut dir = match env::var("BUCKLE_HOME") {
         Ok(home) => Ok(PathBuf::from(home)),
         Err(_) => match env::consts::OS {
@@ -174,7 +174,7 @@ fn read_buck2_version() -> Result<String, Error> {
 }
 
 fn get_buck2_path() -> Result<PathBuf, Error> {
-    let buck2_dir = get_buck2_dir()?;
+    let buck2_dir = get_buckle_dir()?;
     if !buck2_dir.exists() {
         fs::create_dir_all(&buck2_dir)?;
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -171,7 +171,8 @@ fn read_buck2_version() -> Result<String, Error> {
 }
 
 fn get_buck2_path() -> Result<PathBuf, Error> {
-    let buck2_dir = get_buckle_dir()?;
+    let buck2_dir = get_buckle_dir()?.join("buck2");
+
     if !buck2_dir.exists() {
         fs::create_dir_all(&buck2_dir)?;
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,10 +6,7 @@ use std::{
     path::{Path, PathBuf},
     process::{Command, Stdio},
 };
-use std::{
-    io::Write,
-    time::SystemTime,
-};
+use std::{io::Write, time::SystemTime};
 use url::Url;
 
 #[cfg(unix)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -116,14 +116,14 @@ fn get_arch() -> Result<&'static str, Error> {
     Ok(match env::consts::ARCH {
         "x86_64" => match env::consts::OS {
             "linux" => "x86_64-unknown-linux-gnu",
-            "darwin" => "x86_64-apple-darwin",
+            "darwin" | "macos" => "x86_64-apple-darwin",
             "windows" => "x86_64-pc-windows-msvc",
-            _ => return Err(anyhow!("Unsupported Arch/OS")),
+            unknown => return Err(anyhow!("Unsupported Arch/OS {}", unknown)),
         },
         "aarch64" => match env::consts::OS {
             "linux" => "aarch64-unknown-linux-gnu",
-            "darwin" => "aarch64-apple-darwin",
-            _ => return Err(anyhow!("Unsupported Arch/OS")),
+            "darwin" | "macos" => "aarch64-apple-darwin",
+            unknown => return Err(anyhow!("Unsupported Arch/OS {}", unknown)),
         },
         _ => return Err(anyhow!("Unsupported Architecture")),
     })

--- a/tests/integration_buck2.rs
+++ b/tests/integration_buck2.rs
@@ -8,7 +8,7 @@ fn test_buck2_latest() {
     cmd.arg("--version");
     let assert = cmd.assert();
     let stderr = String::from_utf8(assert.get_output().stderr.to_vec()).unwrap();
-    assert!(stderr.contains("/buckle"), "found {}", stderr);
+    assert!(stderr.contains("/buckle/buck2/"), "found {}", stderr);
     let stdout = String::from_utf8(assert.get_output().stdout.to_vec()).unwrap();
     assert!(stdout.starts_with("buck2 "), "found {}", stdout);
     assert.success();


### PR DESCRIPTION
detect macos as darwin

As per https://doc.rust-lang.org/stable/rustc/platform-support.html,   macos is known as darwin in the target triples

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/benbrittain/buckle/pull/11).
* #13
* #10
* #9
* #12
* __->__ #11
* #8
* #6
* #7
* #5