### PR TITLE
Fix URL of Windows artifacts

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -141,7 +141,7 @@ fn get_arch() -> Result<&'static str, Error> {
         "x86_64" => match env::consts::OS {
             "linux" => "x86_64-unknown-linux-musl",
             "darwin" | "macos" => "x86_64-apple-darwin",
-            "windows" => "x86_64-pc-windows-msvc",
+            "windows" => "x86_64-pc-windows-msvc.exe",
             unknown => return Err(anyhow!("Unsupported Arch/OS: x86_64/{unknown}")),
         },
         "aarch64" => match env::consts::OS {

--- a/tests/integration_buck2.rs
+++ b/tests/integration_buck2.rs
@@ -8,7 +8,14 @@ fn test_buck2_latest() {
     cmd.arg("--version");
     let assert = cmd.assert();
     let stdout = String::from_utf8(assert.get_output().stdout.to_vec()).unwrap();
-    assert!(stdout.starts_with("buck2 "), "found {}", stdout);
+    let stderr = String::from_utf8(assert.get_output().stderr.to_vec()).unwrap();
+
+    assert!(
+        stdout.starts_with("buck2 "),
+        "found {} on stdout. stderr was {}",
+        stdout,
+        stderr
+    );
     assert.success();
 }
 
@@ -22,6 +29,12 @@ fn test_buck2_specific_version() {
     // TODO verify the right version is download after buck2 properly states it's version
     let assert = cmd.assert();
     let stdout = String::from_utf8(assert.get_output().stdout.to_vec()).unwrap();
-    assert!(stdout.starts_with("buck2 "), "found {}", stdout);
+    let stderr = String::from_utf8(assert.get_output().stderr.to_vec()).unwrap();
+    assert!(
+        stdout.starts_with("buck2 "),
+        "found {} on stdout. stderr was {}",
+        stdout,
+        stderr
+    );
     assert.success();
 }


### PR DESCRIPTION
They end in `.exe`.

Also my integration tests were failing because buckle was failing due to a corrupted cache, but I couldn't see that because stderr wasn't being reported in the error message. I added stderr to the command assertions.