### PR TITLE
Add option to verify sha256 hash for buck2 tarballs in BuckleConfigFile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,6 +84,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bstr"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -107,6 +116,7 @@ dependencies = [
  "rust-ini",
  "serde",
  "serde_json",
+ "sha2",
  "tempfile",
  "termcolor",
  "url",
@@ -191,16 +201,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crunchy"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
 name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
 
 [[package]]
 name = "dlv-list"
@@ -309,6 +348,16 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -508,9 +557,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.153"
+version = "0.2.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
 
 [[package]]
 name = "libgit2-sys"
@@ -956,6 +1005,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1176,6 +1236,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "typenum"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1219,6 +1285,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wait-timeout"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ once_cell = "1.18.0"
 git2 = { version = "0.17.2", default-features = false }
 termcolor = "1.2.0"
 config = { version = "0.14.0", default-features = false, features = ["toml"] }
+sha2 = "0.10.8"
 
 [dev-dependencies]
 assert_cmd = "2.0.11"

--- a/tests/.buckleconfig.toml
+++ b/tests/.buckleconfig.toml
@@ -1,4 +1,5 @@
 buck2_version = 2025-03-15
 base_download_url = "https://github.com/facebook/buck2/releases/download"
 check_prelude = true
-sha256 = "fde26e31d44a24b0934f69ba11451cc069c470ca7d21913eab1c4b2e7d435010"
+# Can't add this in the test as its platform specific, the below works fine on macos locally
+# sha256 = "fde26e31d44a24b0934f69ba11451cc069c470ca7d21913eab1c4b2e7d435010"

--- a/tests/.buckleconfig.toml
+++ b/tests/.buckleconfig.toml
@@ -1,0 +1,4 @@
+buck2_version = 2025-03-15
+base_download_url = "https://github.com/facebook/buck2/releases/download"
+check_prelude = true
+sha256 = "fde26e31d44a24b0934f69ba11451cc069c470ca7d21913eab1c4b2e7d435010"

--- a/tests/integration_buck2.rs
+++ b/tests/integration_buck2.rs
@@ -1,3 +1,5 @@
+use std::path::Path;
+
 #[cfg(test)]
 use assert_cmd::Command;
 
@@ -23,5 +25,19 @@ fn test_buck2_specific_version() {
     let assert = cmd.assert();
     let stdout = String::from_utf8(assert.get_output().stdout.to_vec()).unwrap();
     assert!(stdout.starts_with("buck2 "), "found {}", stdout);
+    assert.success();
+}
+
+/// Integration test for basic buckleconfig params
+#[test]
+fn test_config() {
+    let mut cmd = Command::cargo_bin("buckle").unwrap();
+    cmd.arg("--version");
+    // Change the directory to `tests` which contains our config
+    cmd.current_dir(Path::new("tests"));
+
+    let assert = cmd.assert();
+    let stdout = String::from_utf8(assert.get_output().stdout.to_vec()).unwrap();
+    assert!(stdout.contains("buck2 "), "found {}", stdout);
     assert.success();
 }


### PR DESCRIPTION
- Corrupt buck2 downloads can go unnoticed without sha256 verification

- Added sanity integration test for config

- Follow minor cargo clippy suggestion